### PR TITLE
feat: Transactional Outbox pattern — Telco SIM activation domain

### DIFF
--- a/src/main/java/com/saurabhshcs/adtech/microservices/designpattern/outbox/telco/command/SIMCardCommand.java
+++ b/src/main/java/com/saurabhshcs/adtech/microservices/designpattern/outbox/telco/command/SIMCardCommand.java
@@ -1,0 +1,30 @@
+package com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.command;
+
+/**
+ * Sealed command hierarchy for SIM card operations.
+ *
+ * <p>Using sealed interfaces + records gives us compile-time exhaustive pattern matching
+ * in the command handler's switch expression.
+ */
+public sealed interface SIMCardCommand
+        permits SIMCardCommand.RegisterSIMCommand,
+                SIMCardCommand.ActivateSIMCommand,
+                SIMCardCommand.SuspendSIMCommand,
+                SIMCardCommand.TerminateSIMCommand,
+                SIMCardCommand.ReactivateSIMCommand {
+
+    /** Register a new SIM with the telco system before network provisioning. */
+    record RegisterSIMCommand(String iccid, String msisdn, String customerId) implements SIMCardCommand {}
+
+    /** Provision the SIM on the network and allow the subscriber to make calls/data. */
+    record ActivateSIMCommand(String simId) implements SIMCardCommand {}
+
+    /** Temporarily deactivate the SIM (e.g., unpaid bill, fraud alert). */
+    record SuspendSIMCommand(String simId, String reason) implements SIMCardCommand {}
+
+    /** Permanently deactivate the SIM (e.g., contract end, porting out). */
+    record TerminateSIMCommand(String simId, String reason) implements SIMCardCommand {}
+
+    /** Restore a suspended SIM to active after the blocking condition is resolved. */
+    record ReactivateSIMCommand(String simId) implements SIMCardCommand {}
+}

--- a/src/main/java/com/saurabhshcs/adtech/microservices/designpattern/outbox/telco/domain/SIMActivationStatus.java
+++ b/src/main/java/com/saurabhshcs/adtech/microservices/designpattern/outbox/telco/domain/SIMActivationStatus.java
@@ -1,0 +1,15 @@
+package com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.domain;
+
+/**
+ * Lifecycle states of a SIM card in the telco network.
+ */
+public enum SIMActivationStatus {
+    /** SIM registered but not yet provisioned on the network. */
+    PENDING,
+    /** SIM is fully active and usable by the subscriber. */
+    ACTIVE,
+    /** SIM temporarily deactivated (e.g., non-payment, fraud hold). */
+    SUSPENDED,
+    /** SIM permanently deactivated; cannot be reactivated. */
+    TERMINATED
+}

--- a/src/main/java/com/saurabhshcs/adtech/microservices/designpattern/outbox/telco/domain/SIMCard.java
+++ b/src/main/java/com/saurabhshcs/adtech/microservices/designpattern/outbox/telco/domain/SIMCard.java
@@ -1,0 +1,127 @@
+package com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.domain;
+
+import com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.event.SIMCardEvent;
+import lombok.Getter;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Aggregate root representing a physical SIM card in the telco network.
+ *
+ * <p>Domain rules:
+ * <ul>
+ *   <li>A SIM starts in {@code PENDING} after registration.</li>
+ *   <li>Only a {@code PENDING} SIM can be activated.</li>
+ *   <li>Only an {@code ACTIVE} SIM can be suspended.</li>
+ *   <li>Only a {@code SUSPENDED} SIM can be reactivated.</li>
+ *   <li>Any non-TERMINATED SIM can be terminated.</li>
+ * </ul>
+ *
+ * <p>All state mutations produce domain events stored in {@code pendingEvents}.
+ * Callers must drain events via {@link #drainPendingEvents()} after persisting the aggregate.
+ */
+@Getter
+public class SIMCard {
+
+    private final String simId;
+    /** ICCID — 19-20 digit SIM serial number printed on the card. */
+    private final String iccid;
+    /** MSISDN — the subscriber's phone number (E.164 format). */
+    private final String msisdn;
+    private final String customerId;
+    private SIMActivationStatus status;
+    private Instant createdAt;
+    private Instant updatedAt;
+
+    private final List<SIMCardEvent> pendingEvents = new ArrayList<>();
+
+    private SIMCard(String simId, String iccid, String msisdn, String customerId) {
+        this.simId = simId;
+        this.iccid = iccid;
+        this.msisdn = msisdn;
+        this.customerId = customerId;
+        this.status = SIMActivationStatus.PENDING;
+        this.createdAt = Instant.now();
+        this.updatedAt = createdAt;
+    }
+
+    // -------------------------------------------------------------------------
+    // Factory
+    // -------------------------------------------------------------------------
+
+    public static SIMCard register(String iccid, String msisdn, String customerId) {
+        if (iccid == null || iccid.isBlank())       throw new IllegalArgumentException("ICCID cannot be blank");
+        if (msisdn == null || msisdn.isBlank())     throw new IllegalArgumentException("MSISDN cannot be blank");
+        if (customerId == null || customerId.isBlank()) throw new IllegalArgumentException("Customer ID cannot be blank");
+
+        String simId = UUID.randomUUID().toString();
+        SIMCard sim = new SIMCard(simId, iccid, msisdn, customerId);
+        sim.pendingEvents.add(new SIMCardEvent.SIMRegisteredEvent(simId, iccid, msisdn, customerId, sim.createdAt));
+        return sim;
+    }
+
+    // -------------------------------------------------------------------------
+    // Business operations
+    // -------------------------------------------------------------------------
+
+    public void activate() {
+        requireStatus(SIMActivationStatus.PENDING, "activated");
+        this.status = SIMActivationStatus.ACTIVE;
+        this.updatedAt = Instant.now();
+        pendingEvents.add(new SIMCardEvent.SIMActivatedEvent(simId, msisdn, customerId, updatedAt));
+    }
+
+    public void suspend(String reason) {
+        if (reason == null || reason.isBlank()) throw new IllegalArgumentException("Suspension reason cannot be blank");
+        requireStatus(SIMActivationStatus.ACTIVE, "suspended");
+        this.status = SIMActivationStatus.SUSPENDED;
+        this.updatedAt = Instant.now();
+        pendingEvents.add(new SIMCardEvent.SIMSuspendedEvent(simId, msisdn, customerId, reason, updatedAt));
+    }
+
+    public void reactivate() {
+        requireStatus(SIMActivationStatus.SUSPENDED, "reactivated");
+        this.status = SIMActivationStatus.ACTIVE;
+        this.updatedAt = Instant.now();
+        pendingEvents.add(new SIMCardEvent.SIMReactivatedEvent(simId, msisdn, customerId, updatedAt));
+    }
+
+    public void terminate(String reason) {
+        if (reason == null || reason.isBlank()) throw new IllegalArgumentException("Termination reason cannot be blank");
+        if (status == SIMActivationStatus.TERMINATED) {
+            throw new IllegalStateException("SIM " + simId + " is already terminated");
+        }
+        this.status = SIMActivationStatus.TERMINATED;
+        this.updatedAt = Instant.now();
+        pendingEvents.add(new SIMCardEvent.SIMTerminatedEvent(simId, msisdn, customerId, reason, updatedAt));
+    }
+
+    // -------------------------------------------------------------------------
+    // Event sourcing helper
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns all pending domain events and clears the internal list.
+     * Must be called after persisting the aggregate to avoid re-publishing events.
+     */
+    public List<SIMCardEvent> drainPendingEvents() {
+        List<SIMCardEvent> snapshot = Collections.unmodifiableList(new ArrayList<>(pendingEvents));
+        pendingEvents.clear();
+        return snapshot;
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    private void requireStatus(SIMActivationStatus required, String operation) {
+        if (status != required) {
+            throw new IllegalStateException(
+                    String.format("SIM %s cannot be %s from state: %s", simId, operation, status));
+        }
+    }
+}

--- a/src/main/java/com/saurabhshcs/adtech/microservices/designpattern/outbox/telco/event/SIMCardEvent.java
+++ b/src/main/java/com/saurabhshcs/adtech/microservices/designpattern/outbox/telco/event/SIMCardEvent.java
@@ -1,0 +1,59 @@
+package com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.event;
+
+import java.time.Instant;
+
+/**
+ * Sealed domain event hierarchy for SIM card lifecycle changes.
+ *
+ * <p>These events are:
+ * <ol>
+ *   <li>Emitted by the {@code SIMCard} aggregate after each state mutation.</li>
+ *   <li>Written atomically to the outbox table by {@code SIMCardCommandService}.</li>
+ *   <li>Relayed to downstream consumers (billing, provisioning, notifications) by {@code OutboxRelayService}.</li>
+ * </ol>
+ */
+public sealed interface SIMCardEvent
+        permits SIMCardEvent.SIMRegisteredEvent,
+                SIMCardEvent.SIMActivatedEvent,
+                SIMCardEvent.SIMSuspendedEvent,
+                SIMCardEvent.SIMTerminatedEvent,
+                SIMCardEvent.SIMReactivatedEvent {
+
+    /** Fired when a SIM is registered in the system, awaiting network provisioning. */
+    record SIMRegisteredEvent(
+            String simId,
+            String iccid,
+            String msisdn,
+            String customerId,
+            Instant occurredAt) implements SIMCardEvent {}
+
+    /** Fired when a SIM is fully provisioned and the subscriber can use the service. */
+    record SIMActivatedEvent(
+            String simId,
+            String msisdn,
+            String customerId,
+            Instant occurredAt) implements SIMCardEvent {}
+
+    /** Fired when a SIM is suspended; billing pauses, network access is blocked. */
+    record SIMSuspendedEvent(
+            String simId,
+            String msisdn,
+            String customerId,
+            String reason,
+            Instant occurredAt) implements SIMCardEvent {}
+
+    /** Fired when a SIM is permanently terminated; number is returned to pool. */
+    record SIMTerminatedEvent(
+            String simId,
+            String msisdn,
+            String customerId,
+            String reason,
+            Instant occurredAt) implements SIMCardEvent {}
+
+    /** Fired when a suspended SIM is restored to active service. */
+    record SIMReactivatedEvent(
+            String simId,
+            String msisdn,
+            String customerId,
+            Instant occurredAt) implements SIMCardEvent {}
+}

--- a/src/main/java/com/saurabhshcs/adtech/microservices/designpattern/outbox/telco/outbox/InMemoryOutboxRepository.java
+++ b/src/main/java/com/saurabhshcs/adtech/microservices/designpattern/outbox/telco/outbox/InMemoryOutboxRepository.java
@@ -1,0 +1,50 @@
+package com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.outbox;
+
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+/**
+ * Thread-safe in-memory implementation of {@link OutboxRepository}.
+ *
+ * <p>Intended for demo and unit tests only. In production replace with a JPA/JDBC
+ * repository backed by the same transactional database as the business data.
+ */
+@Repository
+public class InMemoryOutboxRepository implements OutboxRepository {
+
+    private final Map<String, OutboxMessage> store = new ConcurrentHashMap<>();
+
+    @Override
+    public void save(OutboxMessage message) {
+        store.put(message.getMessageId(), message);
+    }
+
+    @Override
+    public List<OutboxMessage> findPendingMessages() {
+        return store.values().stream()
+                .filter(m -> m.getStatus() == OutboxStatus.PENDING)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<OutboxMessage> findAll() {
+        return new ArrayList<>(store.values());
+    }
+
+    @Override
+    public void update(OutboxMessage message) {
+        store.put(message.getMessageId(), message);
+    }
+
+    @Override
+    public int countByStatus(OutboxStatus status) {
+        return (int) store.values().stream()
+                .filter(m -> m.getStatus() == status)
+                .count();
+    }
+}

--- a/src/main/java/com/saurabhshcs/adtech/microservices/designpattern/outbox/telco/outbox/OutboxMessage.java
+++ b/src/main/java/com/saurabhshcs/adtech/microservices/designpattern/outbox/telco/outbox/OutboxMessage.java
@@ -1,0 +1,61 @@
+package com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.outbox;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.Instant;
+
+/**
+ * A single row in the transactional outbox table.
+ *
+ * <p>Created atomically alongside the business entity update (same DB transaction).
+ * The {@link com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.relay.OutboxRelayService}
+ * polls for {@code PENDING} rows and publishes them to the message broker.
+ */
+@Getter
+@Builder
+public class OutboxMessage {
+
+    /** Unique message identifier (UUID). */
+    private final String messageId;
+
+    /** Business entity ID that caused this event (e.g., SIM card ID). */
+    private final String aggregateId;
+
+    /** Type of the business aggregate (e.g., {@code "SIMCard"}). */
+    private final String aggregateType;
+
+    /** Simple class name of the domain event (e.g., {@code "SIMActivatedEvent"}). */
+    private final String eventType;
+
+    /** JSON-serialized event payload for the message broker. */
+    private final String payload;
+
+    /** Current processing state of this outbox record. */
+    private OutboxStatus status;
+
+    /** Timestamp when this row was written to the outbox. */
+    private final Instant createdAt;
+
+    /** Timestamp of the last relay attempt (null if not yet attempted). */
+    private Instant processedAt;
+
+    /** Number of failed relay attempts; used for dead-letter decisions. */
+    @Builder.Default
+    private int retryCount = 0;
+
+    // -------------------------------------------------------------------------
+    // State transitions (called by the relay service)
+    // -------------------------------------------------------------------------
+
+    public void markPublished() {
+        this.status = OutboxStatus.PUBLISHED;
+        this.processedAt = Instant.now();
+    }
+
+    public void markFailed() {
+        this.status = OutboxStatus.FAILED;
+        this.retryCount++;
+        this.processedAt = Instant.now();
+    }
+}

--- a/src/main/java/com/saurabhshcs/adtech/microservices/designpattern/outbox/telco/outbox/OutboxRepository.java
+++ b/src/main/java/com/saurabhshcs/adtech/microservices/designpattern/outbox/telco/outbox/OutboxRepository.java
@@ -1,0 +1,27 @@
+package com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.outbox;
+
+import java.util.List;
+
+/**
+ * Port for accessing the outbox table.
+ *
+ * <p>In production this maps to a real database table. In tests and the demo the
+ * {@link InMemoryOutboxRepository} implementation is used.
+ */
+public interface OutboxRepository {
+
+    /** Persist a new outbox message (always in {@code PENDING} status). */
+    void save(OutboxMessage message);
+
+    /** Return all messages in {@code PENDING} status for the relay to process. */
+    List<OutboxMessage> findPendingMessages();
+
+    /** Return every message regardless of status (useful for auditing / tests). */
+    List<OutboxMessage> findAll();
+
+    /** Persist status and timestamp changes made by the relay service. */
+    void update(OutboxMessage message);
+
+    /** Count messages by status — primarily used in tests and monitoring. */
+    int countByStatus(OutboxStatus status);
+}

--- a/src/main/java/com/saurabhshcs/adtech/microservices/designpattern/outbox/telco/outbox/OutboxStatus.java
+++ b/src/main/java/com/saurabhshcs/adtech/microservices/designpattern/outbox/telco/outbox/OutboxStatus.java
@@ -1,0 +1,13 @@
+package com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.outbox;
+
+/**
+ * Processing state of a message in the transactional outbox table.
+ */
+public enum OutboxStatus {
+    /** Written by the command service; not yet picked up by the relay. */
+    PENDING,
+    /** Successfully published to the message broker by the relay. */
+    PUBLISHED,
+    /** Relay attempted to publish but received an exception from the broker. */
+    FAILED
+}

--- a/src/main/java/com/saurabhshcs/adtech/microservices/designpattern/outbox/telco/publisher/InMemoryMessageBrokerPublisher.java
+++ b/src/main/java/com/saurabhshcs/adtech/microservices/designpattern/outbox/telco/publisher/InMemoryMessageBrokerPublisher.java
@@ -1,0 +1,36 @@
+package com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.publisher;
+
+import com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.outbox.OutboxMessage;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * In-memory broker publisher for demo and integration testing.
+ *
+ * <p>Simulates a message broker by collecting published messages in a thread-safe list.
+ * In a real telco deployment this would be replaced by a Kafka producer, pushing events to
+ * topics such as {@code sim.activated}, {@code sim.suspended}, etc.
+ */
+@Slf4j
+@Component
+public class InMemoryMessageBrokerPublisher implements MessageBrokerPublisher {
+
+    @Getter
+    private final List<OutboxMessage> publishedMessages = new CopyOnWriteArrayList<>();
+
+    @Override
+    public void publish(OutboxMessage message) {
+        log.info("[BROKER] Publishing event: type={}, aggregateId={}, messageId={}",
+                message.getEventType(), message.getAggregateId(), message.getMessageId());
+        publishedMessages.add(message);
+    }
+
+    /** Reset the published message log (useful between test cases). */
+    public void clear() {
+        publishedMessages.clear();
+    }
+}

--- a/src/main/java/com/saurabhshcs/adtech/microservices/designpattern/outbox/telco/publisher/MessageBrokerPublisher.java
+++ b/src/main/java/com/saurabhshcs/adtech/microservices/designpattern/outbox/telco/publisher/MessageBrokerPublisher.java
@@ -1,0 +1,20 @@
+package com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.publisher;
+
+import com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.outbox.OutboxMessage;
+
+/**
+ * Port for publishing outbox messages to a message broker.
+ *
+ * <p>Production implementations may target Kafka, RabbitMQ, AWS SNS, etc.
+ * The {@link InMemoryMessageBrokerPublisher} is used in tests and the demo.
+ */
+public interface MessageBrokerPublisher {
+
+    /**
+     * Publish a single outbox message to the broker.
+     *
+     * @param message the outbox message whose payload and routing metadata should be sent
+     * @throws RuntimeException if the broker is unavailable; the relay marks the message FAILED
+     */
+    void publish(OutboxMessage message);
+}

--- a/src/main/java/com/saurabhshcs/adtech/microservices/designpattern/outbox/telco/relay/OutboxRelayService.java
+++ b/src/main/java/com/saurabhshcs/adtech/microservices/designpattern/outbox/telco/relay/OutboxRelayService.java
@@ -1,0 +1,69 @@
+package com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.relay;
+
+import com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.outbox.OutboxMessage;
+import com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.outbox.OutboxRepository;
+import com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.publisher.MessageBrokerPublisher;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * Outbox relay — the second half of the Transactional Outbox pattern.
+ *
+ * <p>Responsibilities:
+ * <ol>
+ *   <li>Poll the outbox table for {@code PENDING} messages.</li>
+ *   <li>Publish each message to the message broker via {@link MessageBrokerPublisher}.</li>
+ *   <li>Mark the message {@code PUBLISHED} on success or {@code FAILED} on exception.</li>
+ * </ol>
+ *
+ * <p>In production this service is triggered by a scheduled task (e.g., {@code @Scheduled})
+ * or a dedicated CDC tool (Debezium) watching the outbox table for row inserts.
+ *
+ * <p><b>Idempotency:</b> Only {@code PENDING} rows are processed; already-published rows
+ * are never re-sent, making repeated relay runs safe.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OutboxRelayService {
+
+    private final OutboxRepository outboxRepository;
+    private final MessageBrokerPublisher messageBrokerPublisher;
+
+    /**
+     * Relay all pending outbox messages to the message broker.
+     *
+     * @return the number of messages successfully published in this run
+     */
+    public int relayPendingMessages() {
+        List<OutboxMessage> pending = outboxRepository.findPendingMessages();
+        if (pending.isEmpty()) {
+            log.debug("[RELAY] No pending outbox messages.");
+            return 0;
+        }
+
+        log.info("[RELAY] Processing {} pending outbox message(s).", pending.size());
+        int published = 0;
+
+        for (OutboxMessage message : pending) {
+            try {
+                messageBrokerPublisher.publish(message);
+                message.markPublished();
+                outboxRepository.update(message);
+                published++;
+                log.info("[RELAY] Published messageId={} eventType={}", message.getMessageId(), message.getEventType());
+            } catch (Exception ex) {
+                message.markFailed();
+                outboxRepository.update(message);
+                log.error("[RELAY] Failed to publish messageId={} (attempt #{}): {}",
+                        message.getMessageId(), message.getRetryCount(), ex.getMessage(), ex);
+            }
+        }
+
+        log.info("[RELAY] Relay run complete: published={}, failed={}.", published, pending.size() - published);
+        return published;
+    }
+}

--- a/src/main/java/com/saurabhshcs/adtech/microservices/designpattern/outbox/telco/repository/InMemorySIMCardRepository.java
+++ b/src/main/java/com/saurabhshcs/adtech/microservices/designpattern/outbox/telco/repository/InMemorySIMCardRepository.java
@@ -1,0 +1,44 @@
+package com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.repository;
+
+import com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.domain.SIMCard;
+import org.springframework.stereotype.Repository;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Thread-safe in-memory implementation of {@link SIMCardRepository}.
+ *
+ * <p>Replace with a JPA/JDBC repository in production, ensuring that
+ * saves to this store and the outbox table share the same database transaction.
+ */
+@Repository
+public class InMemorySIMCardRepository implements SIMCardRepository {
+
+    private final Map<String, SIMCard> store = new ConcurrentHashMap<>();
+
+    @Override
+    public void save(SIMCard simCard) {
+        store.put(simCard.getSimId(), simCard);
+    }
+
+    @Override
+    public Optional<SIMCard> findById(String simId) {
+        return Optional.ofNullable(store.get(simId));
+    }
+
+    @Override
+    public Optional<SIMCard> findByMsisdn(String msisdn) {
+        return store.values().stream()
+                .filter(s -> s.getMsisdn().equals(msisdn))
+                .findFirst();
+    }
+
+    @Override
+    public Optional<SIMCard> findByIccid(String iccid) {
+        return store.values().stream()
+                .filter(s -> s.getIccid().equals(iccid))
+                .findFirst();
+    }
+}

--- a/src/main/java/com/saurabhshcs/adtech/microservices/designpattern/outbox/telco/repository/SIMCardRepository.java
+++ b/src/main/java/com/saurabhshcs/adtech/microservices/designpattern/outbox/telco/repository/SIMCardRepository.java
@@ -1,0 +1,22 @@
+package com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.repository;
+
+import com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.domain.SIMCard;
+
+import java.util.Optional;
+
+/**
+ * Port for persisting and retrieving {@link SIMCard} aggregates.
+ *
+ * <p>In production this maps to a JPA repository backed by PostgreSQL (or equivalent).
+ * In the demo the {@link InMemorySIMCardRepository} is used.
+ */
+public interface SIMCardRepository {
+
+    void save(SIMCard simCard);
+
+    Optional<SIMCard> findById(String simId);
+
+    Optional<SIMCard> findByMsisdn(String msisdn);
+
+    Optional<SIMCard> findByIccid(String iccid);
+}

--- a/src/main/java/com/saurabhshcs/adtech/microservices/designpattern/outbox/telco/service/SIMCardCommandService.java
+++ b/src/main/java/com/saurabhshcs/adtech/microservices/designpattern/outbox/telco/service/SIMCardCommandService.java
@@ -1,0 +1,167 @@
+package com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.command.SIMCardCommand;
+import com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.domain.SIMCard;
+import com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.event.SIMCardEvent;
+import com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.outbox.OutboxMessage;
+import com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.outbox.OutboxRepository;
+import com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.outbox.OutboxStatus;
+import com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.repository.SIMCardRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Write-side service for SIM card operations.
+ *
+ * <p><b>Transactional Outbox guarantee</b>: every command handler must:
+ * <ol>
+ *   <li>Mutate the {@link SIMCard} aggregate and persist it via {@link SIMCardRepository}.</li>
+ *   <li>Drain pending domain events and write each to the outbox via {@link OutboxRepository}.</li>
+ * </ol>
+ * Both operations happen in the same logical "transaction". In production, wrap the method body
+ * in {@code @Transactional} and ensure both repositories share the same {@code DataSource}.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SIMCardCommandService {
+
+    private final SIMCardRepository simCardRepository;
+    private final OutboxRepository outboxRepository;
+    private final ObjectMapper objectMapper;
+
+    public SIMCard handle(SIMCardCommand command) {
+        return switch (command) {
+            case SIMCardCommand.RegisterSIMCommand cmd  -> registerSIM(cmd);
+            case SIMCardCommand.ActivateSIMCommand cmd  -> activateSIM(cmd);
+            case SIMCardCommand.SuspendSIMCommand cmd   -> suspendSIM(cmd);
+            case SIMCardCommand.TerminateSIMCommand cmd -> terminateSIM(cmd);
+            case SIMCardCommand.ReactivateSIMCommand cmd -> reactivateSIM(cmd);
+        };
+    }
+
+    // -------------------------------------------------------------------------
+    // Command handlers
+    // -------------------------------------------------------------------------
+
+    private SIMCard registerSIM(SIMCardCommand.RegisterSIMCommand cmd) {
+        SIMCard sim = SIMCard.register(cmd.iccid(), cmd.msisdn(), cmd.customerId());
+        persistAtomically(sim);
+        log.info("SIM registered: simId={}, msisdn={}", sim.getSimId(), sim.getMsisdn());
+        return sim;
+    }
+
+    private SIMCard activateSIM(SIMCardCommand.ActivateSIMCommand cmd) {
+        SIMCard sim = findOrThrow(cmd.simId());
+        sim.activate();
+        persistAtomically(sim);
+        log.info("SIM activated: simId={}, msisdn={}", sim.getSimId(), sim.getMsisdn());
+        return sim;
+    }
+
+    private SIMCard suspendSIM(SIMCardCommand.SuspendSIMCommand cmd) {
+        SIMCard sim = findOrThrow(cmd.simId());
+        sim.suspend(cmd.reason());
+        persistAtomically(sim);
+        log.info("SIM suspended: simId={}, reason={}", sim.getSimId(), cmd.reason());
+        return sim;
+    }
+
+    private SIMCard terminateSIM(SIMCardCommand.TerminateSIMCommand cmd) {
+        SIMCard sim = findOrThrow(cmd.simId());
+        sim.terminate(cmd.reason());
+        persistAtomically(sim);
+        log.info("SIM terminated: simId={}, reason={}", sim.getSimId(), cmd.reason());
+        return sim;
+    }
+
+    private SIMCard reactivateSIM(SIMCardCommand.ReactivateSIMCommand cmd) {
+        SIMCard sim = findOrThrow(cmd.simId());
+        sim.reactivate();
+        persistAtomically(sim);
+        log.info("SIM reactivated: simId={}", sim.getSimId());
+        return sim;
+    }
+
+    // -------------------------------------------------------------------------
+    // Outbox write — the core of the pattern
+    // -------------------------------------------------------------------------
+
+    /**
+     * Atomically persist the aggregate and write outbox messages for all pending events.
+     * In production this whole method must execute inside a single DB transaction.
+     */
+    private void persistAtomically(SIMCard sim) {
+        simCardRepository.save(sim);
+        List<SIMCardEvent> events = sim.drainPendingEvents();
+        events.forEach(this::writeOutboxMessage);
+    }
+
+    private void writeOutboxMessage(SIMCardEvent event) {
+        OutboxMessage outboxMessage = OutboxMessage.builder()
+                .messageId(UUID.randomUUID().toString())
+                .aggregateId(aggregateIdOf(event))
+                .aggregateType("SIMCard")
+                .eventType(event.getClass().getSimpleName())
+                .payload(serialize(event))
+                .status(OutboxStatus.PENDING)
+                .createdAt(Instant.now())
+                .build();
+
+        outboxRepository.save(outboxMessage);
+        log.debug("Outbox message written: messageId={}, eventType={}",
+                outboxMessage.getMessageId(), outboxMessage.getEventType());
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private SIMCard findOrThrow(String simId) {
+        return simCardRepository.findById(simId)
+                .orElseThrow(() -> new IllegalArgumentException("SIM card not found: " + simId));
+    }
+
+    private String aggregateIdOf(SIMCardEvent event) {
+        return switch (event) {
+            case SIMCardEvent.SIMRegisteredEvent e  -> e.simId();
+            case SIMCardEvent.SIMActivatedEvent e   -> e.simId();
+            case SIMCardEvent.SIMSuspendedEvent e   -> e.simId();
+            case SIMCardEvent.SIMTerminatedEvent e  -> e.simId();
+            case SIMCardEvent.SIMReactivatedEvent e -> e.simId();
+        };
+    }
+
+    private String serialize(SIMCardEvent event) {
+        Map<String, Object> payload = switch (event) {
+            case SIMCardEvent.SIMRegisteredEvent e -> Map.of(
+                    "simId", e.simId(), "iccid", e.iccid(), "msisdn", e.msisdn(),
+                    "customerId", e.customerId(), "occurredAt", e.occurredAt().toString());
+            case SIMCardEvent.SIMActivatedEvent e -> Map.of(
+                    "simId", e.simId(), "msisdn", e.msisdn(),
+                    "customerId", e.customerId(), "occurredAt", e.occurredAt().toString());
+            case SIMCardEvent.SIMSuspendedEvent e -> Map.of(
+                    "simId", e.simId(), "msisdn", e.msisdn(), "customerId", e.customerId(),
+                    "reason", e.reason(), "occurredAt", e.occurredAt().toString());
+            case SIMCardEvent.SIMTerminatedEvent e -> Map.of(
+                    "simId", e.simId(), "msisdn", e.msisdn(), "customerId", e.customerId(),
+                    "reason", e.reason(), "occurredAt", e.occurredAt().toString());
+            case SIMCardEvent.SIMReactivatedEvent e -> Map.of(
+                    "simId", e.simId(), "msisdn", e.msisdn(),
+                    "customerId", e.customerId(), "occurredAt", e.occurredAt().toString());
+        };
+        try {
+            return objectMapper.writeValueAsString(payload);
+        } catch (JsonProcessingException ex) {
+            throw new RuntimeException("Failed to serialize event: " + event.getClass().getSimpleName(), ex);
+        }
+    }
+}

--- a/src/main/java/com/saurabhshcs/adtech/microservices/designpattern/outbox/telco/service/SIMCardQueryService.java
+++ b/src/main/java/com/saurabhshcs/adtech/microservices/designpattern/outbox/telco/service/SIMCardQueryService.java
@@ -1,0 +1,53 @@
+package com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.service;
+
+import com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.domain.SIMCard;
+import com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.outbox.OutboxMessage;
+import com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.outbox.OutboxRepository;
+import com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.outbox.OutboxStatus;
+import com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.repository.SIMCardRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Read-side service for SIM card and outbox queries.
+ *
+ * <p>In a full CQRS setup this would read from a separate read model / read replica.
+ * For the outbox pattern demo it reads directly from the in-memory stores.
+ */
+@Service
+@RequiredArgsConstructor
+public class SIMCardQueryService {
+
+    private final SIMCardRepository simCardRepository;
+    private final OutboxRepository outboxRepository;
+
+    public SIMCard findById(String simId) {
+        return simCardRepository.findById(simId)
+                .orElseThrow(() -> new IllegalArgumentException("SIM card not found: " + simId));
+    }
+
+    public Optional<SIMCard> findByMsisdn(String msisdn) {
+        return simCardRepository.findByMsisdn(msisdn);
+    }
+
+    public Optional<SIMCard> findByIccid(String iccid) {
+        return simCardRepository.findByIccid(iccid);
+    }
+
+    /** Return all outbox messages that have not yet been relayed to the broker. */
+    public List<OutboxMessage> findPendingOutboxMessages() {
+        return outboxRepository.findPendingMessages();
+    }
+
+    /** Return all outbox messages regardless of status (for audit / ops dashboards). */
+    public List<OutboxMessage> findAllOutboxMessages() {
+        return outboxRepository.findAll();
+    }
+
+    public int countOutboxMessagesByStatus(OutboxStatus status) {
+        return outboxRepository.countByStatus(status);
+    }
+}

--- a/src/main/resources/docs/transactional-outbox-guide.md
+++ b/src/main/resources/docs/transactional-outbox-guide.md
@@ -1,0 +1,498 @@
+# Transactional Outbox Pattern — Telco SIM Activation Platform
+
+## Table of Contents
+
+1. [The Problem: Dual-Write in Distributed Systems](#the-problem)
+2. [The Solution: Transactional Outbox](#the-solution)
+3. [Telco Domain Scenario](#telco-domain-scenario)
+4. [Architecture Overview](#architecture-overview)
+5. [Key Components](#key-components)
+6. [Data Flow Walkthrough](#data-flow-walkthrough)
+7. [Domain Model & State Machines](#domain-model--state-machines)
+8. [Code Deep Dive](#code-deep-dive)
+9. [Testing Strategy](#testing-strategy)
+10. [Production Considerations](#production-considerations)
+11. [Comparison: Outbox vs Alternatives](#comparison-outbox-vs-alternatives)
+12. [Running the Demo](#running-the-demo)
+
+---
+
+## The Problem
+
+In a telco SIM activation platform, when a subscriber activates a SIM card, **multiple things must happen consistently**:
+
+1. Update the SIM card record in the database (`status = ACTIVE`).
+2. Notify the **Billing Service** to start charging the subscriber.
+3. Notify **Network Provisioning** to open data/voice channels on the HLR.
+4. Send a **Welcome SMS** via the Notification Service.
+
+A naive implementation would use a "dual-write" approach: update the database, then publish a Kafka event. This creates a critical gap:
+
+```
+DB commit succeeds  ──►  [CRASH / network timeout]  ──►  Kafka publish never happens
+                                                          ↓
+                              Billing never starts billing the customer
+                              Network never opens the channel
+                              Customer calls support — angry
+```
+
+The reverse is equally bad: Kafka publish succeeds but the DB rollbacks. Downstream services act on an event that never materialised in the source of truth.
+
+---
+
+## The Solution
+
+The **Transactional Outbox Pattern** eliminates the dual-write problem by:
+
+1. Writing the business entity change **and** an outbox message row to the **same database** in the **same transaction**.
+2. Using a separate **relay service** (or CDC tool) to asynchronously read the outbox and publish to the broker.
+
+Because steps (1a) and (1b) share a transaction, they either both commit or both roll back. The relay can be retried safely because it checks the outbox status before publishing.
+
+```
+┌─────────────────────────────────────┐
+│        Same DB Transaction          │
+│  ┌───────────────┐  ┌─────────────┐│
+│  │ SIM Card row  │  │ Outbox row  ││
+│  │ status=ACTIVE │  │ PENDING     ││
+│  └───────────────┘  └─────────────┘│
+└─────────────────────────────────────┘
+           ↓ committed atomically
+
+  [OutboxRelayService polls later]
+           ↓
+  Kafka ← publish event ← mark PUBLISHED
+```
+
+---
+
+## Telco Domain Scenario
+
+**Company:** TelcoNova — a European mobile network operator
+**Domain:** SIM card lifecycle management
+**Scale:** ~50,000 SIM state changes per hour at peak (new phone launches, billing cycles)
+
+### Business Events That Must Reach Downstream Systems
+
+| Domain Event | Triggers |
+|---|---|
+| `SIMRegisteredEvent` | Creates a subscriber record in billing; reserves MSISDN |
+| `SIMActivatedEvent` | Opens network channels; starts billing; sends welcome SMS |
+| `SIMSuspendedEvent` | Blocks network access; pauses billing; sends SMS alert |
+| `SIMReactivatedEvent` | Restores network; resumes billing; sends confirmation SMS |
+| `SIMTerminatedEvent` | Terminates billing; releases MSISDN back to number pool |
+
+### Why Outbox Over Direct Kafka Publish?
+
+- A SIM activation during a Kafka cluster outage **must not be lost**. Outbox rows persist in PostgreSQL even if Kafka is down for hours.
+- Support teams need an **audit trail** of every event written (the outbox table serves this purpose).
+- The relay can be throttled independently from the write path to protect downstream systems.
+
+---
+
+## Architecture Overview
+
+See `transactional-outbox-pattern.puml` for rendered diagrams. Key elements:
+
+```
+Operator
+   │ ActivateSIMCommand
+   ▼
+SIMCardCommandService
+   ├── SIMCard.activate()            ← domain logic
+   ├── SIMCardRepository.save()      ┐
+   └── OutboxRepository.save()       ┘ same transaction
+                                        │
+                                   (committed)
+                                        │
+                              OutboxRelayService (scheduled)
+                                        │
+                               MessageBrokerPublisher
+                                        │
+                                    Kafka topic
+                              ┌────────┴────────┐
+                         Billing          Network
+                         Service        Provisioning
+```
+
+---
+
+## Key Components
+
+### Domain Layer
+
+| Class | Responsibility |
+|---|---|
+| `SIMCard` | Aggregate root. Enforces business rules. Emits domain events. |
+| `SIMActivationStatus` | Enum: `PENDING → ACTIVE → SUSPENDED → TERMINATED` |
+| `SIMCardEvent` | Sealed interface with five event records. |
+| `SIMCardCommand` | Sealed interface with five command records. |
+
+### Infrastructure Layer
+
+| Class | Responsibility |
+|---|---|
+| `OutboxMessage` | One row in the outbox table. Carries payload + metadata. |
+| `OutboxStatus` | Enum: `PENDING`, `PUBLISHED`, `FAILED` |
+| `InMemoryOutboxRepository` | Demo/test implementation of `OutboxRepository`. |
+| `InMemorySIMCardRepository` | Demo/test implementation of `SIMCardRepository`. |
+| `InMemoryMessageBrokerPublisher` | Captures published events in a list for testing. |
+
+### Service Layer
+
+| Class | Responsibility |
+|---|---|
+| `SIMCardCommandService` | Handles commands; owns the atomic write (SIM + outbox). |
+| `SIMCardQueryService` | Reads SIM state and outbox metrics. |
+| `OutboxRelayService` | Polls `PENDING` outbox rows; publishes; marks `PUBLISHED`/`FAILED`. |
+
+---
+
+## Data Flow Walkthrough
+
+### Step 1 — Operator Sends Command
+
+```java
+commandService.handle(new SIMCardCommand.ActivateSIMCommand(simId));
+```
+
+### Step 2 — Aggregate Enforces Domain Rules
+
+```java
+// Inside SIMCard.activate()
+requireStatus(SIMActivationStatus.PENDING, "activated");   // throws if wrong state
+this.status = SIMActivationStatus.ACTIVE;
+pendingEvents.add(new SIMCardEvent.SIMActivatedEvent(...));
+```
+
+### Step 3 — Atomic Persistence
+
+```java
+// Inside SIMCardCommandService.persistAtomically()
+simCardRepository.save(sim);           // SIM row committed
+List<SIMCardEvent> events = sim.drainPendingEvents();
+events.forEach(this::writeOutboxMessage);  // Outbox row committed
+```
+
+> In production, annotate `persistAtomically()` with `@Transactional`. Both repositories must share the same `DataSource`.
+
+### Step 4 — Relay Publishes Asynchronously
+
+```java
+// Inside OutboxRelayService.relayPendingMessages()
+List<OutboxMessage> pending = outboxRepository.findPendingMessages();
+for (OutboxMessage msg : pending) {
+    try {
+        messageBrokerPublisher.publish(msg);
+        msg.markPublished();
+        outboxRepository.update(msg);
+    } catch (Exception ex) {
+        msg.markFailed();
+        outboxRepository.update(msg);
+    }
+}
+```
+
+### Step 5 — Downstream Consumers React
+
+Each downstream service subscribes to `sim.events` and filters by `eventType`:
+
+- `SIMActivatedEvent` → Billing starts invoice generation, Network opens HLR channel
+- `SIMSuspendedEvent` → Network blocks MSISDN, SMS service sends "Your service is suspended" message
+
+---
+
+## Domain Model & State Machines
+
+### SIM Card Lifecycle
+
+```
+[Registration]
+      │ RegisterSIMCommand
+      ▼
+   PENDING
+      │ ActivateSIMCommand
+      ▼
+   ACTIVE ◄────────────────────┐
+      │                        │ ReactivateSIMCommand
+      │ SuspendSIMCommand       │
+      ▼                        │
+  SUSPENDED ──────────────────►┘
+      │
+      │ TerminateSIMCommand
+      ▼                        (also reachable from ACTIVE)
+  TERMINATED
+```
+
+### OutboxMessage Lifecycle
+
+```
+[Command Service writes]
+      │
+      ▼
+   PENDING
+   ╱      ╲
+Relay OK  Relay throws
+   │            │
+   ▼            ▼
+PUBLISHED     FAILED ──► (retry on next poll)
+```
+
+---
+
+## Code Deep Dive
+
+### Sealed Command Interface (Java 17)
+
+```java
+public sealed interface SIMCardCommand
+        permits SIMCardCommand.RegisterSIMCommand,
+                SIMCardCommand.ActivateSIMCommand,
+                SIMCardCommand.SuspendSIMCommand,
+                SIMCardCommand.TerminateSIMCommand,
+                SIMCardCommand.ReactivateSIMCommand {
+
+    record RegisterSIMCommand(String iccid, String msisdn, String customerId) implements SIMCardCommand {}
+    record ActivateSIMCommand(String simId) implements SIMCardCommand {}
+    // ...
+}
+```
+
+**Why sealed?** The switch expression in `SIMCardCommandService.handle()` is exhaustive at compile time. Adding a new command without handling it fails the build.
+
+### Command Handler with Exhaustive Switch
+
+```java
+public SIMCard handle(SIMCardCommand command) {
+    return switch (command) {
+        case SIMCardCommand.RegisterSIMCommand cmd   -> registerSIM(cmd);
+        case SIMCardCommand.ActivateSIMCommand cmd   -> activateSIM(cmd);
+        case SIMCardCommand.SuspendSIMCommand cmd    -> suspendSIM(cmd);
+        case SIMCardCommand.TerminateSIMCommand cmd  -> terminateSIM(cmd);
+        case SIMCardCommand.ReactivateSIMCommand cmd -> reactivateSIM(cmd);
+    };
+}
+```
+
+### Atomic Write
+
+```java
+private void persistAtomically(SIMCard sim) {
+    simCardRepository.save(sim);                      // (1) business data
+    List<SIMCardEvent> events = sim.drainPendingEvents();
+    events.forEach(this::writeOutboxMessage);          // (2) outbox rows
+    // Production: both (1) and (2) in @Transactional boundary
+}
+```
+
+### Outbox Message Builder
+
+```java
+OutboxMessage.builder()
+    .messageId(UUID.randomUUID().toString())
+    .aggregateId(simId)
+    .aggregateType("SIMCard")
+    .eventType("SIMActivatedEvent")
+    .payload(objectMapper.writeValueAsString(payloadMap))
+    .status(OutboxStatus.PENDING)
+    .createdAt(Instant.now())
+    .build();
+```
+
+---
+
+## Testing Strategy
+
+### Test Classes
+
+| Class | Type | Coverage |
+|---|---|---|
+| `SIMCardCommandServiceTest` | Unit | Command handling, domain rule enforcement, outbox writes |
+| `OutboxRelayServiceTest` | Unit | Relay happy path, broker failure, partial failure, idempotency |
+| `SIMCardQueryServiceTest` | Unit | findById, findByMsisdn, findByIccid, outbox counts |
+| `SIMCardTransactionalOutboxIntegrationTest` | Integration | Full lifecycle, atomicity, idempotency, multi-SIM |
+
+### Testing the Atomic Guarantee
+
+```java
+@Test
+void simStateAndOutboxBothPresentBeforeRelay() {
+    SIMCard sim = commandService.handle(new RegisterSIMCommand("ICC", "+447900000001", "CUST-1"));
+
+    // Both written before relay runs — proves atomicity
+    assertThat(simCardRepository.findById(sim.getSimId())).isPresent();
+    assertThat(outboxRepository.countByStatus(OutboxStatus.PENDING)).isEqualTo(1);
+
+    // Broker not yet called — relay hasn't run
+    assertThat(broker.getPublishedMessages()).isEmpty();
+}
+```
+
+### Testing Relay Failure Resilience
+
+```java
+@Test
+void marksMessageFailedWhenBrokerThrows() {
+    outboxRepository.save(pendingMessage("SIMActivatedEvent"));
+    doThrow(new RuntimeException("Kafka unavailable")).when(publisher).publish(any());
+
+    relayService.relayPendingMessages();
+
+    assertThat(outboxRepository.countByStatus(OutboxStatus.FAILED)).isEqualTo(1);
+    // Message remains; will be retried
+}
+```
+
+### Testing Idempotency
+
+```java
+@Test
+void relayIsIdempotent() {
+    commandService.handle(new RegisterSIMCommand("ICC", "+447900000002", "CUST-2"));
+
+    int firstRun  = relayService.relayPendingMessages();
+    int secondRun = relayService.relayPendingMessages();
+
+    assertThat(firstRun).isEqualTo(1);
+    assertThat(secondRun).isEqualTo(0);   // Already PUBLISHED — not re-sent
+}
+```
+
+### Run Tests
+
+```bash
+# All outbox tests
+./gradlew test --tests "com.saurabhshcs.adtech.microservices.designpattern.outbox.*"
+
+# Single test class
+./gradlew test --tests "com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.integration.SIMCardTransactionalOutboxIntegrationTest"
+```
+
+---
+
+## Production Considerations
+
+### 1. Real Database Transaction
+
+Annotate the command handler with `@Transactional`:
+
+```java
+@Transactional
+private void persistAtomically(SIMCard sim) { ... }
+```
+
+Both `SIMCardRepository` and `OutboxRepository` must use the **same `DataSource`** (i.e., the same PostgreSQL schema/database). This is the only hard requirement for the pattern to hold.
+
+### 2. Outbox Table Schema (PostgreSQL)
+
+```sql
+CREATE TABLE sim_outbox (
+    message_id     UUID PRIMARY KEY,
+    aggregate_id   VARCHAR(255) NOT NULL,
+    aggregate_type VARCHAR(100) NOT NULL,
+    event_type     VARCHAR(200) NOT NULL,
+    payload        JSONB        NOT NULL,
+    status         VARCHAR(20)  NOT NULL DEFAULT 'PENDING',
+    created_at     TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    processed_at   TIMESTAMPTZ,
+    retry_count    INT          NOT NULL DEFAULT 0
+);
+
+CREATE INDEX idx_sim_outbox_status ON sim_outbox(status) WHERE status = 'PENDING';
+```
+
+### 3. Relay Scheduling
+
+```java
+@Scheduled(fixedDelay = 1000)   // every 1 second
+public void scheduledRelay() {
+    relayService.relayPendingMessages();
+}
+```
+
+Or use **Debezium CDC** to capture PostgreSQL WAL changes on the outbox table — lower latency than polling.
+
+### 4. Dead-Letter Strategy
+
+```java
+private static final int MAX_RETRIES = 5;
+
+if (message.getRetryCount() >= MAX_RETRIES) {
+    message.markDeadLetter();
+    // Move to dead-letter queue / alert ops team
+}
+```
+
+### 5. Kafka Topic Design
+
+```
+sim.events
+  ├── key: simId             (ensures ordering per SIM)
+  └── headers:
+        event-type: SIMActivatedEvent
+        aggregate-type: SIMCard
+        message-id: <UUID>   (deduplication key for at-least-once delivery)
+```
+
+### 6. Observability
+
+- **Metric:** `outbox.pending.count` — alert if > 1,000 for more than 5 minutes
+- **Metric:** `outbox.failed.count` — alert on any non-zero value
+- **Log correlation:** include `messageId` and `aggregateId` in all relay log entries
+
+---
+
+## Comparison: Outbox vs Alternatives
+
+| Approach | Atomicity | Broker failure safe | Complexity |
+|---|---|---|---|
+| **Transactional Outbox** | ✅ | ✅ — message persisted in DB | Medium |
+| Dual-write (no outbox) | ❌ | ❌ — event lost on crash | Low |
+| Distributed transaction (2PC) | ✅ | ✅ | High — requires XA driver |
+| Event Sourcing (event store as truth) | ✅ | ✅ | High |
+| Saga Choreography | ✅ per step | ✅ | Medium-High |
+
+For most telco write workloads, the Transactional Outbox provides the best balance of **reliability vs operational complexity**.
+
+---
+
+## Running the Demo
+
+### Prerequisites
+
+- Java 17+
+- No external services required — all repositories are in-memory
+
+### Build & Test
+
+```bash
+./gradlew clean build
+./gradlew test --tests "com.saurabhshcs.adtech.microservices.designpattern.outbox.*"
+```
+
+### Explore the Pattern
+
+The integration test `SIMCardTransactionalOutboxIntegrationTest#fullSIMLifecycle` runs the complete
+**Register → Activate → Suspend → Reactivate → Terminate** lifecycle and validates:
+
+- Every command produces exactly one outbox message
+- Relay publishes each event in sequence
+- All 5 events arrive at the in-memory broker
+- No pending messages remain after the final relay run
+
+### View Architecture Diagrams
+
+Render `transactional-outbox-pattern.puml` with any PlantUML-compatible tool:
+
+```bash
+# Using PlantUML JAR
+java -jar plantuml.jar src/main/resources/docs/transactional-outbox-pattern.puml
+
+# Or use the VS Code PlantUML extension / IntelliJ diagram plugin
+```
+
+The file contains four diagrams:
+1. **Component architecture** — system-level overview
+2. **SIM Activation sequence** — detailed message flow for one activation
+3. **SIM card state machine** — all valid state transitions
+4. **OutboxMessage lifecycle** — PENDING → PUBLISHED / FAILED states

--- a/src/main/resources/docs/transactional-outbox-pattern.puml
+++ b/src/main/resources/docs/transactional-outbox-pattern.puml
@@ -1,0 +1,207 @@
+@startuml Transactional Outbox — Component Architecture (Telco SIM Activation)
+!theme plain
+skinparam linetype ortho
+skinparam componentStyle rectangle
+skinparam defaultFontSize 13
+
+title Transactional Outbox Pattern — Telco SIM Activation Platform
+
+package "Telco Command Side" #LightBlue {
+    component [SIMCardCommandService] as CmdSvc <<Service>>
+    component [SIMCard\n(Aggregate)] as Agg <<Domain>>
+    component [SIMCardRepository] as SimRepo <<Repository>>
+    component [OutboxRepository] as OutboxRepo <<Repository>>
+}
+
+database "SIM Card Store\n(PostgreSQL / In-Memory)" as SimDB <<Persistence>>
+database "Outbox Table\n(PostgreSQL / In-Memory)" as OutboxDB <<Persistence>>
+
+package "Outbox Relay" #LightYellow {
+    component [OutboxRelayService] as Relay <<Scheduler>>
+    component [MessageBrokerPublisher] as Publisher <<Port>>
+}
+
+queue "Kafka / RabbitMQ\n(topic: sim.events)" as Broker <<Message Broker>>
+
+package "Downstream Consumers" #LightGreen {
+    component [Billing Service] as Billing <<Consumer>>
+    component [Network Provisioning] as Network <<Consumer>>
+    component [SMS Notification] as SMS <<Consumer>>
+}
+
+package "Telco Query Side" #LightCoral {
+    component [SIMCardQueryService] as QuerySvc <<Service>>
+}
+
+' Write path
+CmdSvc --> Agg       : mutates state
+CmdSvc --> SimRepo   : save(simCard)
+CmdSvc --> OutboxRepo : save(outboxMessage)\n[same transaction]
+SimRepo  --> SimDB
+OutboxRepo --> OutboxDB
+
+' Relay path
+Relay --> OutboxRepo  : findPendingMessages()
+Relay --> Publisher   : publish(outboxMessage)
+Relay --> OutboxRepo  : update(PUBLISHED)
+Publisher --> Broker
+
+' Downstream
+Broker --> Billing   : SIMActivatedEvent
+Broker --> Network   : SIMActivatedEvent
+Broker --> SMS       : SIMActivatedEvent
+
+' Query path
+QuerySvc --> SimRepo    : findById / findByMsisdn
+QuerySvc --> OutboxRepo : countByStatus
+
+note top of CmdSvc
+  <b>Atomic guarantee</b>
+  save(simCard) + save(outboxMessage)
+  are committed in the same
+  DB transaction — no dual-write risk
+end note
+
+note top of Relay
+  <b>Polling relay</b>
+  • Runs on @Scheduled interval
+    (or driven by CDC / Debezium)
+  • Only processes PENDING rows
+  • Marks PUBLISHED or FAILED
+  • Idempotent: safe to re-run
+end note
+
+@enduml
+
+@startuml Transactional Outbox — SIM Activation Sequence
+!theme plain
+skinparam sequenceMessageAlign center
+skinparam defaultFontSize 12
+
+title SIM Activation — Transactional Outbox Sequence
+
+actor "Telco Operator" as Operator
+participant "SIMCardCommandService" as CmdSvc
+participant "SIMCard\n(Aggregate)" as SimCard
+participant "SIMCardRepository" as SimRepo
+participant "OutboxRepository" as OutboxRepo
+participant "OutboxRelayService" as Relay
+participant "MessageBrokerPublisher" as Publisher
+participant "Billing Service" as Billing
+participant "Network Provisioning" as Network
+
+== Command Phase (atomic) ==
+
+Operator -> CmdSvc  : handle(ActivateSIMCommand{simId})
+activate CmdSvc
+
+CmdSvc -> SimRepo   : findById(simId)
+SimRepo --> CmdSvc  : SIMCard{status=PENDING}
+
+CmdSvc -> SimCard   : activate()
+activate SimCard
+  SimCard -> SimCard : status ← ACTIVE
+  SimCard -> SimCard : pendingEvents.add(SIMActivatedEvent)
+SimCard --> CmdSvc  : (updated aggregate)
+deactivate SimCard
+
+group "Same DB Transaction"
+  CmdSvc -> SimRepo   : save(simCard{ACTIVE})
+  note right of SimRepo : SIM state committed
+  CmdSvc -> SimCard   : drainPendingEvents()
+  SimCard --> CmdSvc  : [SIMActivatedEvent]
+  CmdSvc -> OutboxRepo : save(OutboxMessage{\n  eventType=SIMActivatedEvent,\n  status=PENDING})
+  note right of OutboxRepo : Outbox row committed
+end
+
+CmdSvc --> Operator : SIMCard{status=ACTIVE}
+deactivate CmdSvc
+
+== Relay Phase (asynchronous, periodic) ==
+
+Relay -> OutboxRepo  : findPendingMessages()
+OutboxRepo --> Relay : [OutboxMessage{SIMActivatedEvent, PENDING}]
+
+Relay -> Publisher   : publish(outboxMessage)
+activate Publisher
+Publisher --> Relay  : OK
+deactivate Publisher
+
+Relay -> OutboxRepo  : update(message{status=PUBLISHED})
+
+Publisher --> Billing  : SIMActivatedEvent payload
+Publisher --> Network  : SIMActivatedEvent payload
+
+note over Billing, Network
+  Downstream services react independently.
+  If relay fails here, message stays PENDING
+  and will be retried on the next poll cycle.
+end note
+
+@enduml
+
+@startuml Transactional Outbox — State Machines
+!theme plain
+skinparam defaultFontSize 12
+
+title SIM Card State Machine
+
+[*] --> PENDING : RegisterSIMCommand
+
+PENDING    --> ACTIVE      : ActivateSIMCommand
+ACTIVE     --> SUSPENDED   : SuspendSIMCommand
+ACTIVE     --> TERMINATED  : TerminateSIMCommand
+SUSPENDED  --> ACTIVE      : ReactivateSIMCommand
+SUSPENDED  --> TERMINATED  : TerminateSIMCommand
+TERMINATED --> [*]
+
+note right of PENDING
+  SIM registered, awaiting
+  network provisioning
+end note
+
+note right of ACTIVE
+  Subscriber can make calls,
+  send SMS, use data
+end note
+
+note right of SUSPENDED
+  Network access blocked;
+  bill still generated
+end note
+
+note right of TERMINATED
+  Number returned to pool.
+  No further state changes allowed.
+end note
+
+@enduml
+
+@startuml Transactional Outbox — Outbox Message Lifecycle
+!theme plain
+skinparam defaultFontSize 12
+
+title OutboxMessage Status Lifecycle
+
+[*] --> PENDING : Command service writes\natomically with SIM state
+
+PENDING --> PUBLISHED : Relay successfully\npublishes to broker
+
+PENDING --> FAILED : Broker throws\nexception
+
+FAILED --> PENDING  : Manual retry /\nnext scheduled run
+
+PUBLISHED --> [*]
+
+note right of PENDING
+  Polled by OutboxRelayService
+  on each scheduled run
+end note
+
+note right of FAILED
+  retryCount is incremented.
+  A DLQ strategy (max retries)
+  can be applied in production.
+end note
+
+@enduml

--- a/src/test/java/com/saurabhshcs/adtech/microservices/designpattern/outbox/telco/integration/SIMCardTransactionalOutboxIntegrationTest.java
+++ b/src/test/java/com/saurabhshcs/adtech/microservices/designpattern/outbox/telco/integration/SIMCardTransactionalOutboxIntegrationTest.java
@@ -1,0 +1,207 @@
+package com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.command.SIMCardCommand;
+import com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.domain.SIMActivationStatus;
+import com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.domain.SIMCard;
+import com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.outbox.InMemoryOutboxRepository;
+import com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.outbox.OutboxStatus;
+import com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.publisher.InMemoryMessageBrokerPublisher;
+import com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.relay.OutboxRelayService;
+import com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.repository.InMemorySIMCardRepository;
+import com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.service.SIMCardCommandService;
+import com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.service.SIMCardQueryService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end integration tests for the Transactional Outbox pattern.
+ *
+ * <p>Wires up the full stack with in-memory implementations and exercises the complete flow:
+ * <ol>
+ *   <li>Business command → aggregate mutation + outbox write (atomic)</li>
+ *   <li>Relay polling → broker publish → outbox status updated</li>
+ *   <li>Downstream state visible via query service</li>
+ * </ol>
+ *
+ * <p>No Spring context is needed — the test manages dependencies explicitly.
+ */
+@DisplayName("SIMCard Transactional Outbox — Integration Tests")
+class SIMCardTransactionalOutboxIntegrationTest {
+
+    private InMemorySIMCardRepository      simCardRepository;
+    private InMemoryOutboxRepository       outboxRepository;
+    private InMemoryMessageBrokerPublisher broker;
+    private SIMCardCommandService          commandService;
+    private OutboxRelayService             relayService;
+    private SIMCardQueryService            queryService;
+
+    @BeforeEach
+    void setUp() {
+        simCardRepository = new InMemorySIMCardRepository();
+        outboxRepository  = new InMemoryOutboxRepository();
+        broker            = new InMemoryMessageBrokerPublisher();
+        commandService    = new SIMCardCommandService(simCardRepository, outboxRepository, new ObjectMapper());
+        relayService      = new OutboxRelayService(outboxRepository, broker);
+        queryService      = new SIMCardQueryService(simCardRepository, outboxRepository);
+    }
+
+    // =========================================================================
+    // Full lifecycle
+    // =========================================================================
+
+    @Test
+    @DisplayName("full SIM lifecycle: register → activate → suspend → reactivate → terminate")
+    void fullSIMLifecycle() {
+        // 1. Register
+        SIMCard sim = commandService.handle(new SIMCardCommand.RegisterSIMCommand(
+                "8991001234567890123", "+447911000001", "CUST-101"));
+
+        assertThat(sim.getStatus()).isEqualTo(SIMActivationStatus.PENDING);
+        assertThat(outboxRepository.countByStatus(OutboxStatus.PENDING)).isEqualTo(1);
+
+        relayPendingAndAssertEvent("SIMRegisteredEvent", 1);
+
+        // 2. Activate
+        commandService.handle(new SIMCardCommand.ActivateSIMCommand(sim.getSimId()));
+        assertThat(queryService.findById(sim.getSimId()).getStatus()).isEqualTo(SIMActivationStatus.ACTIVE);
+
+        relayPendingAndAssertEvent("SIMActivatedEvent", 2);
+
+        // 3. Suspend (non-payment)
+        commandService.handle(new SIMCardCommand.SuspendSIMCommand(sim.getSimId(), "Non-payment"));
+        assertThat(queryService.findById(sim.getSimId()).getStatus()).isEqualTo(SIMActivationStatus.SUSPENDED);
+
+        relayPendingAndAssertEvent("SIMSuspendedEvent", 3);
+
+        // 4. Reactivate
+        commandService.handle(new SIMCardCommand.ReactivateSIMCommand(sim.getSimId()));
+        assertThat(queryService.findById(sim.getSimId()).getStatus()).isEqualTo(SIMActivationStatus.ACTIVE);
+
+        relayPendingAndAssertEvent("SIMReactivatedEvent", 4);
+
+        // 5. Terminate
+        commandService.handle(new SIMCardCommand.TerminateSIMCommand(sim.getSimId(), "Customer request"));
+        assertThat(queryService.findById(sim.getSimId()).getStatus()).isEqualTo(SIMActivationStatus.TERMINATED);
+
+        relayPendingAndAssertEvent("SIMTerminatedEvent", 5);
+
+        // Final state: all 5 outbox messages published, none pending
+        assertThat(outboxRepository.countByStatus(OutboxStatus.PENDING)).isEqualTo(0);
+        assertThat(outboxRepository.countByStatus(OutboxStatus.PUBLISHED)).isEqualTo(5);
+        assertThat(broker.getPublishedMessages()).hasSize(5);
+    }
+
+    // =========================================================================
+    // Atomicity guarantee
+    // =========================================================================
+
+    @Test
+    @DisplayName("SIM state and outbox message are both present before relay runs (atomicity)")
+    void simStateAndOutboxBothPresentBeforeRelay() {
+        SIMCard sim = commandService.handle(new SIMCardCommand.RegisterSIMCommand(
+                "ICC-ATOMIC-TEST", "+447700000001", "CUST-200"));
+
+        // Both persisted — before relay has run
+        assertThat(simCardRepository.findById(sim.getSimId())).isPresent();
+        assertThat(outboxRepository.countByStatus(OutboxStatus.PENDING)).isEqualTo(1);
+
+        // Broker has received nothing yet
+        assertThat(broker.getPublishedMessages()).isEmpty();
+    }
+
+    // =========================================================================
+    // Idempotency
+    // =========================================================================
+
+    @Test
+    @DisplayName("running the relay twice does not re-publish the same message")
+    void relayIsIdempotent() {
+        commandService.handle(new SIMCardCommand.RegisterSIMCommand(
+                "ICC-IDEMPOTENCY", "+447700000002", "CUST-201"));
+
+        int firstRun  = relayService.relayPendingMessages();
+        int secondRun = relayService.relayPendingMessages();
+
+        assertThat(firstRun).isEqualTo(1);
+        assertThat(secondRun).isEqualTo(0);
+        assertThat(broker.getPublishedMessages()).hasSize(1);
+    }
+
+    // =========================================================================
+    // Multiple SIMs
+    // =========================================================================
+
+    @Test
+    @DisplayName("batch: activating 3 SIMs produces 3 isolated outbox messages")
+    void batchActivationProducesIsolatedOutboxMessages() {
+        SIMCard sim1 = commandService.handle(new SIMCardCommand.RegisterSIMCommand("ICC-A", "+447000000001", "CUST-A"));
+        SIMCard sim2 = commandService.handle(new SIMCardCommand.RegisterSIMCommand("ICC-B", "+447000000002", "CUST-B"));
+        SIMCard sim3 = commandService.handle(new SIMCardCommand.RegisterSIMCommand("ICC-C", "+447000000003", "CUST-C"));
+
+        assertThat(outboxRepository.countByStatus(OutboxStatus.PENDING)).isEqualTo(3);
+
+        int relayed = relayService.relayPendingMessages();
+
+        assertThat(relayed).isEqualTo(3);
+        assertThat(broker.getPublishedMessages()).hasSize(3);
+        assertThat(outboxRepository.countByStatus(OutboxStatus.PUBLISHED)).isEqualTo(3);
+    }
+
+    // =========================================================================
+    // Query service
+    // =========================================================================
+
+    @Test
+    @DisplayName("query service returns current SIM state after each command")
+    void queryServiceReflectsLatestState() {
+        SIMCard sim = commandService.handle(new SIMCardCommand.RegisterSIMCommand(
+                "ICC-QUERY", "+447900000099", "CUST-Q1"));
+
+        assertThat(queryService.findById(sim.getSimId()).getStatus()).isEqualTo(SIMActivationStatus.PENDING);
+
+        commandService.handle(new SIMCardCommand.ActivateSIMCommand(sim.getSimId()));
+        assertThat(queryService.findById(sim.getSimId()).getStatus()).isEqualTo(SIMActivationStatus.ACTIVE);
+
+        commandService.handle(new SIMCardCommand.SuspendSIMCommand(sim.getSimId(), "Fraud"));
+        assertThat(queryService.findById(sim.getSimId()).getStatus()).isEqualTo(SIMActivationStatus.SUSPENDED);
+    }
+
+    @Test
+    @DisplayName("query service can locate SIM by MSISDN")
+    void queryServiceFindsSimByMsisdn() {
+        commandService.handle(new SIMCardCommand.RegisterSIMCommand(
+                "ICC-MSISDN-TEST", "+447911234567", "CUST-M1"));
+
+        assertThat(queryService.findByMsisdn("+447911234567")).isPresent();
+        assertThat(queryService.findByMsisdn("+00000000000")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("query service pending-outbox count decreases after relay")
+    void pendingOutboxCountDecreasesAfterRelay() {
+        commandService.handle(new SIMCardCommand.RegisterSIMCommand("ICC-CNT", "+447911000099", "CUST-C1"));
+
+        assertThat(queryService.countOutboxMessagesByStatus(OutboxStatus.PENDING)).isEqualTo(1);
+
+        relayService.relayPendingMessages();
+
+        assertThat(queryService.countOutboxMessagesByStatus(OutboxStatus.PENDING)).isEqualTo(0);
+        assertThat(queryService.countOutboxMessagesByStatus(OutboxStatus.PUBLISHED)).isEqualTo(1);
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private void relayPendingAndAssertEvent(String expectedEventType, int expectedBrokerTotal) {
+        int relayed = relayService.relayPendingMessages();
+        assertThat(relayed).isEqualTo(1);
+        assertThat(broker.getPublishedMessages()).hasSize(expectedBrokerTotal);
+        assertThat(broker.getPublishedMessages().get(expectedBrokerTotal - 1).getEventType())
+                .isEqualTo(expectedEventType);
+    }
+}

--- a/src/test/java/com/saurabhshcs/adtech/microservices/designpattern/outbox/telco/relay/OutboxRelayServiceTest.java
+++ b/src/test/java/com/saurabhshcs/adtech/microservices/designpattern/outbox/telco/relay/OutboxRelayServiceTest.java
@@ -1,0 +1,212 @@
+package com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.relay;
+
+import com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.outbox.InMemoryOutboxRepository;
+import com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.outbox.OutboxMessage;
+import com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.outbox.OutboxStatus;
+import com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.publisher.MessageBrokerPublisher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link OutboxRelayService}.
+ *
+ * <p>Uses a real {@link InMemoryOutboxRepository} and a mock {@link MessageBrokerPublisher}
+ * to drive the relay through happy-path and failure scenarios.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("OutboxRelayService")
+class OutboxRelayServiceTest {
+
+    private InMemoryOutboxRepository outboxRepository;
+
+    @Mock
+    private MessageBrokerPublisher messageBrokerPublisher;
+
+    private OutboxRelayService relayService;
+
+    @BeforeEach
+    void setUp() {
+        outboxRepository = new InMemoryOutboxRepository();
+        relayService     = new OutboxRelayService(outboxRepository, messageBrokerPublisher);
+    }
+
+    // =========================================================================
+    // Happy path
+    // =========================================================================
+
+    @Nested
+    @DisplayName("successful relay")
+    class SuccessfulRelay {
+
+        @Test
+        @DisplayName("relays all pending messages and marks them PUBLISHED")
+        void relaysAllPendingMessages() {
+            outboxRepository.save(pendingMessage("SIMActivatedEvent"));
+            outboxRepository.save(pendingMessage("SIMSuspendedEvent"));
+
+            int count = relayService.relayPendingMessages();
+
+            assertThat(count).isEqualTo(2);
+            verify(messageBrokerPublisher, times(2)).publish(any());
+            assertThat(outboxRepository.countByStatus(OutboxStatus.PUBLISHED)).isEqualTo(2);
+            assertThat(outboxRepository.countByStatus(OutboxStatus.PENDING)).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("returns 0 when there are no pending messages")
+        void returnsZeroWhenNoPendingMessages() {
+            int count = relayService.relayPendingMessages();
+
+            assertThat(count).isEqualTo(0);
+            verify(messageBrokerPublisher, never()).publish(any());
+        }
+
+        @Test
+        @DisplayName("does not relay already-published messages")
+        void doesNotRelayAlreadyPublishedMessages() {
+            OutboxMessage alreadyPublished = pendingMessage("SIMActivatedEvent");
+            alreadyPublished.markPublished();
+            outboxRepository.save(alreadyPublished);
+
+            int count = relayService.relayPendingMessages();
+
+            assertThat(count).isEqualTo(0);
+            verify(messageBrokerPublisher, never()).publish(any());
+        }
+
+        @Test
+        @DisplayName("does not relay FAILED messages in the same run")
+        void doesNotRelayFailedMessages() {
+            OutboxMessage failed = pendingMessage("SIMActivatedEvent");
+            failed.markFailed();
+            outboxRepository.save(failed);
+
+            int count = relayService.relayPendingMessages();
+
+            assertThat(count).isEqualTo(0);
+            verify(messageBrokerPublisher, never()).publish(any());
+        }
+    }
+
+    // =========================================================================
+    // Failure handling
+    // =========================================================================
+
+    @Nested
+    @DisplayName("broker failure handling")
+    class BrokerFailureHandling {
+
+        @Test
+        @DisplayName("marks message FAILED when broker throws an exception")
+        void marksMessageFailedWhenBrokerThrows() {
+            outboxRepository.save(pendingMessage("SIMActivatedEvent"));
+            doThrow(new RuntimeException("Kafka unavailable")).when(messageBrokerPublisher).publish(any());
+
+            int count = relayService.relayPendingMessages();
+
+            assertThat(count).isEqualTo(0);
+            assertThat(outboxRepository.countByStatus(OutboxStatus.FAILED)).isEqualTo(1);
+            assertThat(outboxRepository.countByStatus(OutboxStatus.PUBLISHED)).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("increments retryCount on each failure")
+        void incrementsRetryCountOnFailure() {
+            OutboxMessage msg = pendingMessage("SIMActivatedEvent");
+            outboxRepository.save(msg);
+            doThrow(new RuntimeException("broker down")).when(messageBrokerPublisher).publish(any());
+
+            relayService.relayPendingMessages();
+
+            OutboxMessage stored = outboxRepository.findAll().get(0);
+            assertThat(stored.getRetryCount()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("partially relays when only some messages fail")
+        void partiallyRelaysWhenSomeMessagesFail() {
+            outboxRepository.save(pendingMessage("SIMActivatedEvent"));
+            outboxRepository.save(pendingMessage("SIMSuspendedEvent"));
+
+            // first call throws, second succeeds
+            doThrow(new RuntimeException("broker error"))
+                    .doNothing()
+                    .when(messageBrokerPublisher).publish(any());
+
+            int count = relayService.relayPendingMessages();
+
+            assertThat(count).isEqualTo(1);
+            assertThat(outboxRepository.countByStatus(OutboxStatus.PUBLISHED)).isEqualTo(1);
+            assertThat(outboxRepository.countByStatus(OutboxStatus.FAILED)).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("relay continues processing remaining messages after one failure")
+        void continuesAfterFailure() {
+            // 3 messages; first one will fail
+            outboxRepository.save(pendingMessage("SIMRegisteredEvent"));
+            outboxRepository.save(pendingMessage("SIMActivatedEvent"));
+            outboxRepository.save(pendingMessage("SIMTerminatedEvent"));
+
+            doThrow(new RuntimeException("transient error"))
+                    .doNothing()
+                    .doNothing()
+                    .when(messageBrokerPublisher).publish(any());
+
+            int count = relayService.relayPendingMessages();
+
+            assertThat(count).isEqualTo(2);
+            assertThat(outboxRepository.countByStatus(OutboxStatus.PUBLISHED)).isEqualTo(2);
+            assertThat(outboxRepository.countByStatus(OutboxStatus.FAILED)).isEqualTo(1);
+        }
+    }
+
+    // =========================================================================
+    // Idempotency
+    // =========================================================================
+
+    @Nested
+    @DisplayName("idempotency")
+    class Idempotency {
+
+        @Test
+        @DisplayName("re-running the relay after all messages published produces no further publishes")
+        void reRunningRelayIsNoop() {
+            outboxRepository.save(pendingMessage("SIMActivatedEvent"));
+
+            relayService.relayPendingMessages();          // first run
+            int secondRun = relayService.relayPendingMessages(); // second run
+
+            assertThat(secondRun).isEqualTo(0);
+            verify(messageBrokerPublisher, times(1)).publish(any());
+        }
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private OutboxMessage pendingMessage(String eventType) {
+        return OutboxMessage.builder()
+                .messageId(UUID.randomUUID().toString())
+                .aggregateId(UUID.randomUUID().toString())
+                .aggregateType("SIMCard")
+                .eventType(eventType)
+                .payload("{\"simId\":\"test-sim\"}")
+                .status(OutboxStatus.PENDING)
+                .createdAt(Instant.now())
+                .build();
+    }
+}

--- a/src/test/java/com/saurabhshcs/adtech/microservices/designpattern/outbox/telco/service/SIMCardCommandServiceTest.java
+++ b/src/test/java/com/saurabhshcs/adtech/microservices/designpattern/outbox/telco/service/SIMCardCommandServiceTest.java
@@ -318,7 +318,7 @@ class SIMCardCommandServiceTest {
 
         @Test
         @DisplayName("outbox message payload is valid JSON containing simId")
-        void payloadIsValidJsonWithSimId() throws Exception {
+        void payloadIsValidJsonWithSimId() {
             SIMCard sim = registerSIM();
             OutboxMessage msg = outboxRepository.findPendingMessages().get(0);
 

--- a/src/test/java/com/saurabhshcs/adtech/microservices/designpattern/outbox/telco/service/SIMCardCommandServiceTest.java
+++ b/src/test/java/com/saurabhshcs/adtech/microservices/designpattern/outbox/telco/service/SIMCardCommandServiceTest.java
@@ -1,0 +1,371 @@
+package com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.command.SIMCardCommand;
+import com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.domain.SIMActivationStatus;
+import com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.domain.SIMCard;
+import com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.outbox.InMemoryOutboxRepository;
+import com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.outbox.OutboxMessage;
+import com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.outbox.OutboxStatus;
+import com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.repository.InMemorySIMCardRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link SIMCardCommandService}.
+ *
+ * <p>Uses real in-memory repositories — no mocking needed because the repositories are
+ * trivial and deterministic. This mirrors the testing convention used across all patterns
+ * in this project.
+ */
+@DisplayName("SIMCardCommandService")
+class SIMCardCommandServiceTest {
+
+    private InMemorySIMCardRepository simCardRepository;
+    private InMemoryOutboxRepository outboxRepository;
+    private SIMCardCommandService commandService;
+
+    @BeforeEach
+    void setUp() {
+        simCardRepository = new InMemorySIMCardRepository();
+        outboxRepository  = new InMemoryOutboxRepository();
+        commandService    = new SIMCardCommandService(simCardRepository, outboxRepository, new ObjectMapper());
+    }
+
+    // =========================================================================
+    // RegisterSIM
+    // =========================================================================
+
+    @Nested
+    @DisplayName("RegisterSIM command")
+    class RegisterSIM {
+
+        @Test
+        @DisplayName("registers SIM in PENDING state and writes one outbox message")
+        void registersSimAndWritesOutboxEntry() {
+            SIMCard sim = commandService.handle(
+                    new SIMCardCommand.RegisterSIMCommand("8991000001234567891", "+447911123456", "CUST-001"));
+
+            assertThat(sim.getStatus()).isEqualTo(SIMActivationStatus.PENDING);
+            assertThat(sim.getIccid()).isEqualTo("8991000001234567891");
+            assertThat(sim.getMsisdn()).isEqualTo("+447911123456");
+            assertThat(sim.getCustomerId()).isEqualTo("CUST-001");
+            assertThat(sim.getSimId()).isNotBlank();
+
+            List<OutboxMessage> pending = outboxRepository.findPendingMessages();
+            assertThat(pending).hasSize(1);
+            assertThat(pending.get(0).getEventType()).isEqualTo("SIMRegisteredEvent");
+            assertThat(pending.get(0).getAggregateType()).isEqualTo("SIMCard");
+            assertThat(pending.get(0).getStatus()).isEqualTo(OutboxStatus.PENDING);
+            assertThat(pending.get(0).getPayload()).contains("8991000001234567891");
+        }
+
+        @Test
+        @DisplayName("SIM is persisted in the repository after registration")
+        void simIsPersistedAfterRegistration() {
+            SIMCard sim = commandService.handle(
+                    new SIMCardCommand.RegisterSIMCommand("ICC-XYZ", "+1234567890", "CUST-002"));
+
+            assertThat(simCardRepository.findById(sim.getSimId())).isPresent();
+        }
+
+        @Test
+        @DisplayName("rejects blank ICCID")
+        void rejectsBlankIccid() {
+            assertThatThrownBy(() -> commandService.handle(
+                    new SIMCardCommand.RegisterSIMCommand("", "+447911123456", "CUST-001")))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("ICCID");
+        }
+
+        @Test
+        @DisplayName("rejects blank MSISDN")
+        void rejectsBlankMsisdn() {
+            assertThatThrownBy(() -> commandService.handle(
+                    new SIMCardCommand.RegisterSIMCommand("ICC-001", "", "CUST-001")))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("MSISDN");
+        }
+
+        @Test
+        @DisplayName("rejects blank customer ID")
+        void rejectsBlankCustomerId() {
+            assertThatThrownBy(() -> commandService.handle(
+                    new SIMCardCommand.RegisterSIMCommand("ICC-001", "+447911123456", "")))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Customer ID");
+        }
+
+        @Test
+        @DisplayName("null fields are rejected")
+        void rejectsNullFields() {
+            assertThatThrownBy(() -> commandService.handle(
+                    new SIMCardCommand.RegisterSIMCommand(null, "+447911123456", "CUST-001")))
+                    .isInstanceOf(IllegalArgumentException.class);
+
+            assertThatThrownBy(() -> commandService.handle(
+                    new SIMCardCommand.RegisterSIMCommand("ICC-001", null, "CUST-001")))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    // =========================================================================
+    // ActivateSIM
+    // =========================================================================
+
+    @Nested
+    @DisplayName("ActivateSIM command")
+    class ActivateSIM {
+
+        @Test
+        @DisplayName("activates a PENDING SIM and writes SIMActivatedEvent to outbox")
+        void activatesPendingSimAndWritesEvent() {
+            SIMCard sim = registerSIM();
+            clearPendingOutbox();
+
+            SIMCard activated = commandService.handle(new SIMCardCommand.ActivateSIMCommand(sim.getSimId()));
+
+            assertThat(activated.getStatus()).isEqualTo(SIMActivationStatus.ACTIVE);
+            List<OutboxMessage> pending = outboxRepository.findPendingMessages();
+            assertThat(pending).hasSize(1);
+            assertThat(pending.get(0).getEventType()).isEqualTo("SIMActivatedEvent");
+            assertThat(pending.get(0).getAggregateId()).isEqualTo(sim.getSimId());
+        }
+
+        @Test
+        @DisplayName("state change is persisted in the repository")
+        void stateChangeIsPersistedInRepository() {
+            SIMCard sim = registerSIM();
+            commandService.handle(new SIMCardCommand.ActivateSIMCommand(sim.getSimId()));
+
+            SIMCard stored = simCardRepository.findById(sim.getSimId()).orElseThrow();
+            assertThat(stored.getStatus()).isEqualTo(SIMActivationStatus.ACTIVE);
+        }
+
+        @Test
+        @DisplayName("cannot activate an ACTIVE SIM — domain rule enforced")
+        void cannotActivateActiveSim() {
+            SIMCard sim = registerAndActivateSIM();
+
+            assertThatThrownBy(() -> commandService.handle(new SIMCardCommand.ActivateSIMCommand(sim.getSimId())))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("cannot be activated");
+        }
+
+        @Test
+        @DisplayName("throws IllegalArgumentException when SIM ID is unknown")
+        void throwsWhenSimNotFound() {
+            assertThatThrownBy(() -> commandService.handle(new SIMCardCommand.ActivateSIMCommand("ghost-id")))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("SIM card not found");
+        }
+    }
+
+    // =========================================================================
+    // SuspendSIM
+    // =========================================================================
+
+    @Nested
+    @DisplayName("SuspendSIM command")
+    class SuspendSIM {
+
+        @Test
+        @DisplayName("suspends an ACTIVE SIM and writes SIMSuspendedEvent with reason to outbox")
+        void suspendsActiveSimWithReason() {
+            SIMCard sim = registerAndActivateSIM();
+            clearPendingOutbox();
+
+            commandService.handle(new SIMCardCommand.SuspendSIMCommand(sim.getSimId(), "Non-payment"));
+
+            SIMCard stored = simCardRepository.findById(sim.getSimId()).orElseThrow();
+            assertThat(stored.getStatus()).isEqualTo(SIMActivationStatus.SUSPENDED);
+
+            List<OutboxMessage> pending = outboxRepository.findPendingMessages();
+            assertThat(pending).hasSize(1);
+            assertThat(pending.get(0).getEventType()).isEqualTo("SIMSuspendedEvent");
+            assertThat(pending.get(0).getPayload()).contains("Non-payment");
+        }
+
+        @Test
+        @DisplayName("cannot suspend a PENDING SIM")
+        void cannotSuspendPendingSim() {
+            SIMCard sim = registerSIM();
+
+            assertThatThrownBy(() -> commandService.handle(
+                    new SIMCardCommand.SuspendSIMCommand(sim.getSimId(), "fraud")))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("cannot be suspended");
+        }
+
+        @Test
+        @DisplayName("rejects blank suspension reason")
+        void rejectsBlankReason() {
+            SIMCard sim = registerAndActivateSIM();
+
+            assertThatThrownBy(() -> commandService.handle(
+                    new SIMCardCommand.SuspendSIMCommand(sim.getSimId(), "")))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("reason");
+        }
+    }
+
+    // =========================================================================
+    // TerminateSIM
+    // =========================================================================
+
+    @Nested
+    @DisplayName("TerminateSIM command")
+    class TerminateSIM {
+
+        @Test
+        @DisplayName("terminates an ACTIVE SIM and writes SIMTerminatedEvent to outbox")
+        void terminatesActiveSim() {
+            SIMCard sim = registerAndActivateSIM();
+            clearPendingOutbox();
+
+            commandService.handle(new SIMCardCommand.TerminateSIMCommand(sim.getSimId(), "Customer request"));
+
+            assertThat(simCardRepository.findById(sim.getSimId()).orElseThrow().getStatus())
+                    .isEqualTo(SIMActivationStatus.TERMINATED);
+            assertThat(outboxRepository.findPendingMessages().get(0).getEventType())
+                    .isEqualTo("SIMTerminatedEvent");
+        }
+
+        @Test
+        @DisplayName("terminates a SUSPENDED SIM")
+        void terminatesSuspendedSim() {
+            SIMCard sim = registerAndActivateSIM();
+            commandService.handle(new SIMCardCommand.SuspendSIMCommand(sim.getSimId(), "Fraud"));
+            clearPendingOutbox();
+
+            commandService.handle(new SIMCardCommand.TerminateSIMCommand(sim.getSimId(), "Fraud confirmed"));
+
+            assertThat(simCardRepository.findById(sim.getSimId()).orElseThrow().getStatus())
+                    .isEqualTo(SIMActivationStatus.TERMINATED);
+        }
+
+        @Test
+        @DisplayName("cannot terminate an already terminated SIM")
+        void cannotTerminateAlreadyTerminatedSim() {
+            SIMCard sim = registerAndActivateSIM();
+            commandService.handle(new SIMCardCommand.TerminateSIMCommand(sim.getSimId(), "reason"));
+
+            assertThatThrownBy(() -> commandService.handle(
+                    new SIMCardCommand.TerminateSIMCommand(sim.getSimId(), "again")))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("already terminated");
+        }
+    }
+
+    // =========================================================================
+    // ReactivateSIM
+    // =========================================================================
+
+    @Nested
+    @DisplayName("ReactivateSIM command")
+    class ReactivateSIM {
+
+        @Test
+        @DisplayName("reactivates a SUSPENDED SIM and writes SIMReactivatedEvent to outbox")
+        void reactivatesSuspendedSim() {
+            SIMCard sim = registerAndActivateSIM();
+            commandService.handle(new SIMCardCommand.SuspendSIMCommand(sim.getSimId(), "Non-payment"));
+            clearPendingOutbox();
+
+            SIMCard reactivated = commandService.handle(new SIMCardCommand.ReactivateSIMCommand(sim.getSimId()));
+
+            assertThat(reactivated.getStatus()).isEqualTo(SIMActivationStatus.ACTIVE);
+            assertThat(outboxRepository.findPendingMessages().get(0).getEventType())
+                    .isEqualTo("SIMReactivatedEvent");
+        }
+
+        @Test
+        @DisplayName("cannot reactivate an ACTIVE SIM")
+        void cannotReactivateActiveSim() {
+            SIMCard sim = registerAndActivateSIM();
+
+            assertThatThrownBy(() -> commandService.handle(new SIMCardCommand.ReactivateSIMCommand(sim.getSimId())))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("cannot be reactivated");
+        }
+
+        @Test
+        @DisplayName("cannot reactivate a TERMINATED SIM")
+        void cannotReactivateTerminatedSim() {
+            SIMCard sim = registerAndActivateSIM();
+            commandService.handle(new SIMCardCommand.TerminateSIMCommand(sim.getSimId(), "reason"));
+
+            assertThatThrownBy(() -> commandService.handle(new SIMCardCommand.ReactivateSIMCommand(sim.getSimId())))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("cannot be reactivated");
+        }
+    }
+
+    // =========================================================================
+    // Outbox payload integrity
+    // =========================================================================
+
+    @Nested
+    @DisplayName("Outbox payload integrity")
+    class OutboxPayloadIntegrity {
+
+        @Test
+        @DisplayName("outbox message payload is valid JSON containing simId")
+        void payloadIsValidJsonWithSimId() throws Exception {
+            SIMCard sim = registerSIM();
+            OutboxMessage msg = outboxRepository.findPendingMessages().get(0);
+
+            assertThat(msg.getPayload()).startsWith("{");
+            assertThat(msg.getPayload()).contains(sim.getSimId());
+        }
+
+        @Test
+        @DisplayName("outbox message has a non-null messageId and createdAt")
+        void outboxMessageHasMetadata() {
+            registerSIM();
+            OutboxMessage msg = outboxRepository.findPendingMessages().get(0);
+
+            assertThat(msg.getMessageId()).isNotBlank();
+            assertThat(msg.getCreatedAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("each command produces exactly one outbox message")
+        void eachCommandProducesOneOutboxMessage() {
+            SIMCard sim = registerSIM();
+            assertThat(outboxRepository.findPendingMessages()).hasSize(1);
+
+            clearPendingOutbox();
+            commandService.handle(new SIMCardCommand.ActivateSIMCommand(sim.getSimId()));
+            assertThat(outboxRepository.findPendingMessages()).hasSize(1);
+        }
+    }
+
+    // =========================================================================
+    // Test helpers
+    // =========================================================================
+
+    private SIMCard registerSIM() {
+        return commandService.handle(new SIMCardCommand.RegisterSIMCommand(
+                "8991000001234567891", "+447911123456", "CUST-001"));
+    }
+
+    private SIMCard registerAndActivateSIM() {
+        SIMCard sim = registerSIM();
+        return commandService.handle(new SIMCardCommand.ActivateSIMCommand(sim.getSimId()));
+    }
+
+    private void clearPendingOutbox() {
+        outboxRepository.findPendingMessages().forEach(m -> {
+            m.markPublished();
+            outboxRepository.update(m);
+        });
+    }
+}

--- a/src/test/java/com/saurabhshcs/adtech/microservices/designpattern/outbox/telco/service/SIMCardQueryServiceTest.java
+++ b/src/test/java/com/saurabhshcs/adtech/microservices/designpattern/outbox/telco/service/SIMCardQueryServiceTest.java
@@ -1,0 +1,150 @@
+package com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.command.SIMCardCommand;
+import com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.domain.SIMCard;
+import com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.outbox.InMemoryOutboxRepository;
+import com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.outbox.OutboxStatus;
+import com.saurabhshcs.adtech.microservices.designpattern.outbox.telco.repository.InMemorySIMCardRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("SIMCardQueryService")
+class SIMCardQueryServiceTest {
+
+    private InMemorySIMCardRepository simCardRepository;
+    private InMemoryOutboxRepository  outboxRepository;
+    private SIMCardCommandService     commandService;
+    private SIMCardQueryService       queryService;
+
+    @BeforeEach
+    void setUp() {
+        simCardRepository = new InMemorySIMCardRepository();
+        outboxRepository  = new InMemoryOutboxRepository();
+        commandService    = new SIMCardCommandService(simCardRepository, outboxRepository, new ObjectMapper());
+        queryService      = new SIMCardQueryService(simCardRepository, outboxRepository);
+    }
+
+    // -------------------------------------------------------------------------
+    // findById
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("findById returns the correct SIM")
+    void findByIdReturnsCorrectSim() {
+        SIMCard sim = register();
+
+        SIMCard found = queryService.findById(sim.getSimId());
+
+        assertThat(found.getSimId()).isEqualTo(sim.getSimId());
+        assertThat(found.getMsisdn()).isEqualTo("+447911123456");
+    }
+
+    @Test
+    @DisplayName("findById throws when SIM does not exist")
+    void findByIdThrowsWhenNotFound() {
+        assertThatThrownBy(() -> queryService.findById("non-existent"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("SIM card not found");
+    }
+
+    // -------------------------------------------------------------------------
+    // findByMsisdn
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("findByMsisdn returns the SIM for a known number")
+    void findByMsisdnReturnsSimForKnownNumber() {
+        register();
+
+        Optional<SIMCard> found = queryService.findByMsisdn("+447911123456");
+
+        assertThat(found).isPresent();
+        assertThat(found.get().getMsisdn()).isEqualTo("+447911123456");
+    }
+
+    @Test
+    @DisplayName("findByMsisdn returns empty for an unknown number")
+    void findByMsisdnReturnsEmptyForUnknownNumber() {
+        assertThat(queryService.findByMsisdn("+00000000000")).isEmpty();
+    }
+
+    // -------------------------------------------------------------------------
+    // findByIccid
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("findByIccid returns the SIM for a known ICCID")
+    void findByIccidReturnsSimForKnownIccid() {
+        register();
+
+        Optional<SIMCard> found = queryService.findByIccid("8991000001234567891");
+
+        assertThat(found).isPresent();
+        assertThat(found.get().getIccid()).isEqualTo("8991000001234567891");
+    }
+
+    @Test
+    @DisplayName("findByIccid returns empty for an unknown ICCID")
+    void findByIccidReturnsEmptyForUnknownIccid() {
+        assertThat(queryService.findByIccid("UNKNOWN-ICCID")).isEmpty();
+    }
+
+    // -------------------------------------------------------------------------
+    // Outbox queries
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("findPendingOutboxMessages returns only PENDING entries")
+    void findPendingOutboxMessagesReturnsPendingOnly() {
+        register();
+
+        assertThat(queryService.findPendingOutboxMessages()).hasSize(1);
+        assertThat(queryService.findPendingOutboxMessages().get(0).getStatus())
+                .isEqualTo(OutboxStatus.PENDING);
+    }
+
+    @Test
+    @DisplayName("findAllOutboxMessages returns all entries regardless of status")
+    void findAllOutboxMessagesReturnsAll() {
+        SIMCard sim = register();
+        commandService.handle(new SIMCardCommand.ActivateSIMCommand(sim.getSimId()));
+        // mark first message published
+        outboxRepository.findPendingMessages().stream().findFirst().ifPresent(m -> {
+            m.markPublished();
+            outboxRepository.update(m);
+        });
+
+        assertThat(queryService.findAllOutboxMessages()).hasSizeGreaterThanOrEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("countOutboxMessagesByStatus counts correctly per status")
+    void countOutboxMessagesByStatusIsAccurate() {
+        register();
+        register2();
+
+        assertThat(queryService.countOutboxMessagesByStatus(OutboxStatus.PENDING)).isEqualTo(2);
+        assertThat(queryService.countOutboxMessagesByStatus(OutboxStatus.PUBLISHED)).isEqualTo(0);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private SIMCard register() {
+        return commandService.handle(new SIMCardCommand.RegisterSIMCommand(
+                "8991000001234567891", "+447911123456", "CUST-001"));
+    }
+
+    private SIMCard register2() {
+        return commandService.handle(new SIMCardCommand.RegisterSIMCommand(
+                "8991000009999999999", "+447911999999", "CUST-002"));
+    }
+}


### PR DESCRIPTION
## Summary

- **Pattern:** Transactional Outbox — eliminates the dual-write problem when publishing domain events alongside database writes
- **Domain:** Telco SIM card lifecycle (Register → Activate → Suspend → Reactivate → Terminate)
- **Tests added:** 47 new tests, total now **231** (up from 184)

## What's Included

### Production code (15 classes)

| Layer | Classes |
|---|---|
| Domain | `SIMCard` aggregate, `SIMActivationStatus` enum |
| Commands | `SIMCardCommand` sealed interface (5 command records) |
| Events | `SIMCardEvent` sealed interface (5 event records) |
| Outbox | `OutboxMessage`, `OutboxStatus`, `OutboxRepository`, `InMemoryOutboxRepository` |
| Relay | `OutboxRelayService` — polls PENDING rows, publishes to broker, marks PUBLISHED/FAILED |
| Publisher | `MessageBrokerPublisher` port, `InMemoryMessageBrokerPublisher` (demo/test) |
| Repository | `SIMCardRepository` port, `InMemorySIMCardRepository` (demo/test) |
| Services | `SIMCardCommandService` (write side), `SIMCardQueryService` (read side) |

### Test classes (4 classes, 47 tests)

| Class | Type | What it covers |
|---|---|---|
| `SIMCardCommandServiceTest` | Unit | All 5 commands, domain rules, outbox writes, payload integrity |
| `OutboxRelayServiceTest` | Unit | Happy path, broker failure, partial failure, idempotency, retry count |
| `SIMCardQueryServiceTest` | Unit | findById, findByMsisdn, findByIccid, outbox count queries |
| `SIMCardTransactionalOutboxIntegrationTest` | Integration | Full lifecycle, atomicity guarantee, idempotency, multi-SIM batch |

### Architecture artefacts

- `transactional-outbox-pattern.puml` — 4 PlantUML diagrams (component, sequence, SIM state machine, outbox message lifecycle)
- `transactional-outbox-guide.md` — Comprehensive developer guide including problem statement, design decisions, code walkthrough, production checklist (DB transaction, schema, scheduling, dead-letter strategy, observability)

### Build fix

Removed 4 duplicate source files with spaces in their names (`EventStore 2.java`, `InMemoryEventStore 2.java`, etc.) that were causing clean-build failures due to public class/interface name mismatches.

## Key Design Decisions

1. **Sealed types + exhaustive switch** — adding a new `SIMCardCommand` without a handler is a compile error
2. **`persistAtomically()`** — the single method that writes both the SIM aggregate and the outbox row; wrap in `@Transactional` in production
3. **Idempotent relay** — `OutboxRelayService` only queries `PENDING` rows; re-running after a crash never double-publishes
4. **No Spring Boot test context** — all 4 test classes use plain JUnit 5 with real in-memory repos, consistent with the project's existing testing convention

## Test Plan

- [x] `./gradlew clean test` — all 231 tests pass
- [x] Outbox-only filter: `./gradlew test --tests "com.saurabhshcs.adtech.microservices.designpattern.outbox.*"`
- [x] Full lifecycle integration test covers all 5 SIM state transitions and validates zero pending outbox messages at the end

🤖 Generated with [Claude Code](https://claude.com/claude-code)